### PR TITLE
Add overloaded method for publishers.

### DIFF
--- a/src/main/java/info/ganglia/gmetric4j/Publisher.java
+++ b/src/main/java/info/ganglia/gmetric4j/Publisher.java
@@ -8,4 +8,8 @@ public interface Publisher {
 	void publish( String processName, String attributeName, 
 			String value, GMetricType type, GMetricSlope slope, String units )
 				throws GangliaException;
+	
+	void publish( String processName, String attributeName, 
+			String value, GMetricType type, GMetricSlope slope, int delay, String units )
+				throws GangliaException;
 }

--- a/src/main/java/info/ganglia/gmetric4j/gmetric/GMetricPublisher.java
+++ b/src/main/java/info/ganglia/gmetric4j/gmetric/GMetricPublisher.java
@@ -15,4 +15,12 @@ public class GMetricPublisher implements Publisher {
         		slope, 60, 0, processName);
 	}
 
+	@Override
+	public void publish(String processName, String attributeName, String value,
+			GMetricType type, GMetricSlope slope, int delay, String units)
+			throws GangliaException {
+        gm.announce(attributeName, value, type, units, 
+        		slope, delay, 0, processName);	
+	}
+
 }


### PR DESCRIPTION
This will allow any samplers to set the delay in between publishing.
This is a step in fixing ganglia/jmxetric#11
