### PR TITLE
fix host name used for IT

### DIFF
--- a/src/test/java/info/ganglia/gmetric4j/gmetric/GMetricIT.java
+++ b/src/test/java/info/ganglia/gmetric4j/gmetric/GMetricIT.java
@@ -17,7 +17,7 @@ public class GMetricIT {
 
     @Before
     public void setUp() throws IOException {
-        instance = new GMetric("localhost", 8649, UDPAddressingMode.MULTICAST, 1, true);
+        instance = new GMetric("239.2.11.71", 8649, UDPAddressingMode.MULTICAST, 1, true);
     }
 
     /**


### PR DESCRIPTION
`localhost` is resolved to `127.0.0.11` by the underlying protocol, which is not the multicast channel that gmond defaults to. Hence this test was failing. This change fixes that, change `localhost` to `239.2.11.71` and all the tests in `GMetricIT` passes.
