### PR TITLE
Support networkinterface

### DIFF
--- a/src/main/java/info/ganglia/gmetric4j/gmetric/AbstractProtocol.java
+++ b/src/main/java/info/ganglia/gmetric4j/gmetric/AbstractProtocol.java
@@ -29,9 +29,9 @@ public abstract class AbstractProtocol implements Protocol {
         if ( mode == UDPAddressingMode.MULTICAST ) {
             MulticastSocket multicastSocket = new MulticastSocket() ;
             multicastSocket.setTimeToLive(ttl);
-			if ( nif != null && !nif.isEmpty()) {
-				multicastSocket.setNetworkInterface(NetworkInterface.getByName(nif));
-			}
+		    if ( nif != null && !nif.isEmpty()) {
+		        multicastSocket.setNetworkInterface(NetworkInterface.getByName(nif));
+		    }
             this.socket = multicastSocket ;
         } else {
             this.socket = new DatagramSocket() ;

--- a/src/main/java/info/ganglia/gmetric4j/gmetric/AbstractProtocol.java
+++ b/src/main/java/info/ganglia/gmetric4j/gmetric/AbstractProtocol.java
@@ -4,10 +4,7 @@ package info.ganglia.gmetric4j.gmetric;
 import info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode;
 
 import java.io.IOException;
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.InetAddress;
-import java.net.MulticastSocket;
+import java.net.*;
 // import java.util.logging.Level;
 // import java.util.logging.Logger;
 
@@ -23,7 +20,8 @@ public abstract class AbstractProtocol implements Protocol {
     //private static Logger log =
     //    Logger.getLogger(AbstractProtocol.class.getName());
 
-	public AbstractProtocol( String group, int port, UDPAddressingMode mode, int ttl ) throws IOException {
+	public AbstractProtocol( String group, int port, UDPAddressingMode mode, int ttl, 
+							 String nif ) throws IOException {
     	this.group = group ;
     	this.port = port ;
         this.udpAddr = InetAddress.getByName( group ) ;
@@ -31,6 +29,9 @@ public abstract class AbstractProtocol implements Protocol {
         if ( mode == UDPAddressingMode.MULTICAST ) {
             MulticastSocket multicastSocket = new MulticastSocket() ;
             multicastSocket.setTimeToLive(ttl);
+			if ( nif != null && !nif.isEmpty()) {
+				multicastSocket.setNetworkInterface(NetworkInterface.getByName(nif));
+			}
             this.socket = multicastSocket ;
         } else {
             this.socket = new DatagramSocket() ;

--- a/src/main/java/info/ganglia/gmetric4j/gmetric/GMetric.java
+++ b/src/main/java/info/ganglia/gmetric4j/gmetric/GMetric.java
@@ -37,7 +37,25 @@ public class GMetric implements Closeable {
      *            time to live value
      */
     public GMetric(String group, int port, UDPAddressingMode mode, int ttl) throws IOException {
-        this(group, port, mode, ttl, true);
+        this(group, port, mode, ttl, null);
+    }
+
+    /**
+     * Constructs a GMetric
+     * 
+     * @param group
+     *            the host/group to send the event to
+     * @param port
+     *            the port to send the event to
+     * @param mode
+     *            the mode
+     * @param ttl
+     *            time to live value
+     * @param nif
+     *            networkinterface to use send the event to
+     */
+    public GMetric(String group, int port, UDPAddressingMode mode, int ttl, String nif) throws IOException {
+        this(group, port, mode, ttl, nif, true);
     }
 
     /**
@@ -51,11 +69,13 @@ public class GMetric implements Closeable {
      *            adressing mode to be used (UNICAST/MULTICAST)
      * @param ttl
      *            time to live value
+     * @param nif
+     *            networkinterface to use send the event to
      * @param ganglia311
      *            protocol version true=v3.1, false=v3.0
      */
-    public GMetric(String group, int port, UDPAddressingMode mode, int ttl, boolean ganglia311) throws IOException {
-        this(group, port, mode, ttl, ganglia311, null);
+    public GMetric(String group, int port, UDPAddressingMode mode, int ttl, String nif, boolean ganglia311) throws IOException {
+        this(group, port, mode, ttl, nif, ganglia311, null);
     }
 
     /**
@@ -69,17 +89,19 @@ public class GMetric implements Closeable {
      *            adressing mode to be used (UNICAST/MULTICAST)
      * @param ttl
      *            time to live value
+     * @param nif 
+     *            networkinterface to use send the event to
      * @param ganglia311
      *            protocol version true=v3.1, false=v3.0
      * @param uuid
      *            uuid for the host
      */
-    public GMetric(String group, int port, UDPAddressingMode mode, int ttl, boolean ganglia311, UUID uuid)
+    public GMetric(String group, int port, UDPAddressingMode mode, int ttl, String nif, boolean ganglia311, UUID uuid)
             throws IOException {
         if (!ganglia311)
-            this.protocol = new Protocolv30x(group, port, mode, ttl);
+            this.protocol = new Protocolv30x(group, port, mode, ttl, nif);
         else
-            this.protocol = new Protocolv31x(group, port, mode, ttl, 5, uuid, null);
+            this.protocol = new Protocolv31x(group, port, mode, ttl, nif, 5, uuid, null);
     }
 
     /**
@@ -100,12 +122,12 @@ public class GMetric implements Closeable {
      * @param spoof
      *            spoofing information IP:hostname
      */
-    public GMetric(String group, int port, UDPAddressingMode mode, int ttl, boolean ganglia311, UUID uuid, String spoof)
+    public GMetric(String group, int port, UDPAddressingMode mode, int ttl, String nif, boolean ganglia311, UUID uuid, String spoof)
             throws IOException {
         if (!ganglia311)
-            this.protocol = new Protocolv30x(group, port, mode, ttl);
+            this.protocol = new Protocolv30x(group, port, mode, ttl, nif);
         else
-            this.protocol = new Protocolv31x(group, port, mode, ttl, 5, uuid, spoof);
+            this.protocol = new Protocolv31x(group, port, mode, ttl, nif, 5, uuid, spoof);
     }
 
     /**

--- a/src/main/java/info/ganglia/gmetric4j/gmetric/Protocolv30x.java
+++ b/src/main/java/info/ganglia/gmetric4j/gmetric/Protocolv30x.java
@@ -14,8 +14,9 @@ public class Protocolv30x extends AbstractProtocol {
 	private static final int MAX_BUFFER_SIZE = 1024 ;
     private XdrBufferEncodingStream xdr = new XdrBufferEncodingStream( MAX_BUFFER_SIZE );
     
-    public Protocolv30x( String group, int port, UDPAddressingMode mode, int ttl ) throws IOException {
-    	super(group, port, mode, ttl);
+    public Protocolv30x( String group, int port, UDPAddressingMode mode, int ttl, 
+                         String nif ) throws IOException {
+    	super(group, port, mode, ttl, nif);
     }
     
 	@Override

--- a/src/main/java/info/ganglia/gmetric4j/gmetric/Protocolv31x.java
+++ b/src/main/java/info/ganglia/gmetric4j/gmetric/Protocolv31x.java
@@ -29,9 +29,9 @@ public class Protocolv31x extends AbstractProtocol {
     private boolean isSpoofName;
     private String localHostName;
 
-	public Protocolv31x(String group, int port, UDPAddressingMode mode, int ttl, 
+	public Protocolv31x(String group, int port, UDPAddressingMode mode, int ttl, String nif, 
 			int metadataMessageInterval, UUID uuid, String spoofName)  throws IOException {
-		super(group, port, mode, ttl);
+		super(group, port, mode, ttl, nif);
 		this.metadataMessageInterval = metadataMessageInterval ;
 		this.uuid = uuid;
 		if (spoofName != null && !spoofName.isEmpty()) {

--- a/src/test/java/info/ganglia/gmetric4j/gmetric/GMetricIT.java
+++ b/src/test/java/info/ganglia/gmetric4j/gmetric/GMetricIT.java
@@ -17,7 +17,7 @@ public class GMetricIT {
 
     @Before
     public void setUp() throws IOException {
-        instance = new GMetric("239.2.11.71", 8649, UDPAddressingMode.MULTICAST, 1, true);
+        instance = new GMetric("239.2.11.71", 8649, UDPAddressingMode.MULTICAST, 1, null, true);
     }
 
     /**


### PR DESCRIPTION
Gmond uses a specific network interface in case that a machine has a multiple network interfaces. GMetrics should support this situation.
